### PR TITLE
Feature/transfer slot pickers to open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ const appointmentSlot = EmberObject.extend({
   slotPickerLongDayLabel: 'Thursday 28th November' , // optional (defaults to slotPickerDayLabel) (used in slots-picker/selection-single)
 
   slotPickerNotAvailable: false, // optional (default false), to filter out the slots passed to the set of all slots in the components
-  slotPickerNotDisplayable: false // optional (default false), to filter out the slots you want to show, while still including them in the global (to show empty days, for example)
+  slotPickerNotDisplayable: false // optional (default false), to filter out the slots you want to show, while still including them in the global (to show empty days, for example),
+  slotPickerHasTag: false // optional (default false), will display an `fa-tag` icon on slots buttons when true
 });
 ```
 

--- a/addon/components/bg-button/component.js
+++ b/addon/components/bg-button/component.js
@@ -11,6 +11,8 @@ export default Component.extend({
   classNameBindings: ['bgTheme'],
   attributeBindings: ['isDisabled:disabled', 'type', 'tabindex'],
 
+  isTagged: false,
+
   // attributes
   // whether the button is disabled or not
   disabled: false,

--- a/addon/components/bg-button/template.hbs
+++ b/addon/components/bg-button/template.hbs
@@ -9,5 +9,10 @@
       <span class="bg-button-icon fa fa-angle-right" aria-hidden="true"></span>
     {{/if}}
   {{/if}}
+
   {{yield}}
+
+  {{#if isTagged}}
+    <span class="bg-button-icon fa fa-tag" aria-labelledby="tagInfo"></span>
+  {{/if}}
 {{/if}}

--- a/addon/components/slots-picker/button/template.hbs
+++ b/addon/components/slots-picker/button/template.hbs
@@ -11,6 +11,9 @@
   {{else}}
     <div class="asp-appointment-slot-selected white background background-dark-blue">
       {{appointmentSlot.slotPickerTime}}
+      {{#if appointmentSlot.slotPickerHasTag}}
+        <span class="fa fa-tag" aria-labelledby="tagInfo"></span>
+      {{/if}}
       <span class="fa fa-check" aria-hidden="true"></span>
     </div>
   {{/if}}
@@ -19,6 +22,7 @@
     class='asp-btn'
     theme='secondary'
     hide-icon='true'
+    isTagged=appointmentSlot.slotPickerHasTag
     action=(action attrs.select appointmentSlot)}}
     {{appointmentSlot.slotPickerTime}}
   {{/bg-button}}

--- a/addon/services/scroll.js
+++ b/addon/services/scroll.js
@@ -70,7 +70,7 @@ export default Service.extend({
    * @return {undefined}
    */
   to: function (name, options, callback) {
-    if (!this.get('configService.isTestLike')) {
+    if (!this.get('isTestLike')) {
       //console.log('scroll to', name);
       scheduleOnce('afterRender', this, this.afterRenderTo, name, options, callback);
     }

--- a/tests/dummy/app/demo/slots-pickers/route.js
+++ b/tests/dummy/app/demo/slots-pickers/route.js
@@ -41,7 +41,8 @@ export default Route.extend({
         endTime: startMoment.hours(s.endHour).minutes(0).seconds(0).format(),
         variant: s.variant,
         available: Math.random() > 0.75 || notDisplayable,
-        slotPickerNotDisplayable: notDisplayable
+        slotPickerNotDisplayable: notDisplayable,
+        slotPickerHasTag: Math.random() > 0.75
       }));
     }
     const availableSlots = appointmentSlots.filterBy('available', true);

--- a/tests/dummy/app/models/appointment-slot.js
+++ b/tests/dummy/app/models/appointment-slot.js
@@ -116,7 +116,7 @@ export default DS.Model.extend({
   slotPickerDayLabel: computed('_startMoment', function () {
     const _startMoment = this.get('_startMoment');
 
-    return _startMoment.format('ddd Do MMM YYYY');
+    return _startMoment.format('ddd Do MMM');
   }),
 
   slotPickerLongDayLabel: computed('_startMoment', function () {
@@ -127,5 +127,6 @@ export default DS.Model.extend({
 
   slotPickerNotAvailable: not('available'),
 
-  slotPickerNotShowable: false
+  slotPickerNotShowable: false,
+  slotPickerHasTag: false
 });


### PR DESCRIPTION
- [x] add slotPickerHasTag
- [x] fix few typos

Status after this PR:

- [x] transfer slot-picker components to separate, open-source repo. 
- [x] move sly and pickadate bower dependencies out of commons and into npm packages in this repo.
- [x] ~find a solution for `bg-button`, services, helpers and 'scroll-anchor` (should probably not be part of this repo)~ need to be able to tree-shake it out (make a special bg tree-shaking option)
- [ ] allow to tree-shake components
- [ ] allow to tree-shake dependencies
- [ ] create an ember-commons + one app PRs consuming it for backward compatibility
- [ ] make less dependency optional
- [x] reorganize folder structures to have everything under a single namespace instead of flattened components hierarchy
- [x] ~rename the components to `appointment-slots-picker`~
- [x] make sure the latest LTS versions are used in ember-try
- [x] check font-awesome
- [x] github pages
- [ ] check slot-picker/loader image
- [ ] refresh and consume https://github.com/britishgas-engineering/ember-window (and add viewport etc.?) 
- [ ] check consuming better bootstrap in commons
- [ ] add appointment-slot-picker in dummy app + tests
- [ ] use https://www.npmjs.com/package/ember-truth-helpers
- [x] ~look at `.tz` references in the dummy app (add to addon? remove altogether from dummy app?)~ separate card on https://github.com/britishgas-engineering/ember-appointment-slots-pickers/issues/13