### PR TITLE
Feature/transfer slot pickers to open source

### DIFF
--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -1,4 +1,5 @@
 @import (optional) "./variables.less";
+@import (optional) "node_modules/bg-vi/src/styles/bg-vi.less";
 @import "./mixins.less";
 @import (optional) "./global-rules.less";
 //@import "pod-styles"; can not manage to make it work with tree-shaking

--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -1,7 +1,12 @@
+//non "bg" bundles only
 @import (optional) "./variables.less";
-@import (optional) "node_modules/bg-vi/src/styles/bg-vi.less";
+//"bg" bundles only
+@import (optional) "node_modules/bg-vi/src/styles/custom-bg/variables.less";
+@import (optional) "node_modules/bg-vi/src/styles/brands/sainsburys/variables.less";
+@import (optional) "node_modules/bg-vi/src/styles/brands/britishgas/variables.less";
+
 @import "./mixins.less";
-@import (optional) "./global-rules.less";
+@import (optional) "./global-rules.less"; //non "bg" bundles only
 //@import "pod-styles"; can not manage to make it work with tree-shaking
 @import (optional) "./components/clock-reloader/styles.less";
 @import (optional) "./components/date-picker/mobile/styles.less";

--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -1,4 +1,22 @@
-@import "./variables.less";
+@import (optional) "./variables.less";
 @import "./mixins.less";
-@import "./global-rules.less";
-@import "pod-styles";
+@import (optional) "./global-rules.less";
+//@import "pod-styles"; can not manage to make it work with tree-shaking
+@import (optional) "./components/clock-reloader/styles.less";
+@import (optional) "./components/date-picker/mobile/styles.less";
+@import (optional) "./components/horizontal-list-swiper/gesture/styles.less";
+@import (optional) "./components/horizontal-list-swiper/gesture2/styles.less";
+@import (optional) "./components/horizontal-list-swiper/no-delay-on-transitions-in-test/styles.less";
+@import (optional) "./components/horizontal-list-swiper/sly/styles.less";
+@import (optional) "./components/pickadate-input/styles.less";
+@import (optional) "./components/slots-filter/ui/styles.less";
+@import (optional) "./components/slots-picker/button/styles.less";
+@import (optional) "./components/slots-picker/cards/styles.less";
+@import (optional) "./components/slots-picker/day-card/styles.less";
+@import (optional) "./components/slots-picker/desktop/styles.less";
+@import (optional) "./components/slots-picker/loader/styles.less";
+@import (optional) "./components/slots-picker/mobile/styles.less";
+@import (optional) "./components/slots-picker/pickadate/styles.less";
+@import (optional) "./components/slots-picker/selection-multi/styles.less";
+@import (optional) "./components/slots-picker/mobile/styles.less";
+@import (optional) "./components/slots-picker/styles.less";

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 /* jshint node: true */
 'use strict';
+const MergeTrees = require('broccoli-merge-trees');
+
+const Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-appointment-slots-pickers',
@@ -19,5 +22,29 @@ module.exports = {
       return false;
     }
     return true;
-  }
+  },
+  _treeShakingEmber(tree) {
+    const options = this.app.options[this.name];
+    let treeShakingOptions = {};
+
+    if (options) {
+      treeShakingOptions = Object.assign({}, {
+        enabled: true,
+        include: options.include || null,
+        exclude: options.exclude || null
+      });
+    }
+    return new Funnel(tree, treeShakingOptions);
+  },
+  treeForAddon() {
+    const tree = this._super.treeForAddon.apply(this, arguments);
+    return this._treeShakingEmber(tree);
+  },
+
+  treeForApp(appTree) {
+    const trees = [this._treeShakingEmber(appTree)];
+    return new MergeTrees(trees, {
+      overwrite: true
+    });
+  },
 };

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = {
   _treeShakingEmber(tree) {
     const options = this.app.options[this.name];
     let treeShakingOptions = {};
-
+    console.log('options', options, this.app.options, this.name);
     if (options) {
       if (options.bundles) {
         options.exclude = options.exclude || [];

--- a/index.js
+++ b/index.js
@@ -28,6 +28,24 @@ module.exports = {
     let treeShakingOptions = {};
 
     if (options) {
+      if (options.bundles) {
+        options.exclude = options.exclude || [];
+        const bundles = options.bundles;
+        if (bundles.includes('bg')) {
+          options.exclude.push(
+            /services\/scroll/,
+            /services\/viewport/,
+            /helpers/,
+            /styles\/global-rules/,
+            /styles\/mixins/,
+            /styles\/variables/,
+            /components\/application-pre-loader/,
+            /components\/bg-button/,
+            /components\/scroll-anchor/
+          )
+        }
+        delete options.bundles;
+      }
       treeShakingOptions = Object.assign({}, {
         enabled: true,
         include: options.include || null,

--- a/index.js
+++ b/index.js
@@ -46,55 +46,58 @@ module.exports = {
     let treeShakingOptions = {};
     if (options) {
       if (options.bundles) {
-        [/*'include', */'exclude'].forEach((clude) => {
-          options[clude] = options[clude] || [];
-          const bundlesClude = options.bundles[clude];
-          bundlesClude.forEach((bundleName) => {
-            let patterns = [];
-            switch(bundleName) {
-              case 'bg':
-                patterns = [
-                  /services\/scroll/,
-                  /services\/viewport/,
-                  /helpers/,
-                  '**/global-rules.less',
-                  '**/variable.less',
-                  /components\/application-pre-loader/,
-                  /components\/bg-button/,
-                  /components\/scroll-anchor/
-                ];
-                break;
-              case 'mobile':
-                patterns = [
-                  /horizontal-list-swiper\/sly/,
-                  /components\/date-picker\/mobile/,
-                  /components\/date-picker\/mobile\/styles/,
-                  /horizontal-list-swiper\/gesture2/,
-                  /components\/slots-picker\/mobile/
-                ];
-                break;
-              case 'pickadate':
-                patterns = [
-                  /components\/pickadate-input/,
-                  /components\/slots-picker\/pickadate/
-                ];
-                break;
-              case 'desktop':
-                patterns = [
-                  /horizontal-list-swiper\/gesture/,
-                  /components\/slots-picker\/desktop/
-                ];
-                break;
-              case 'cards':
-                patterns = [
-                  /components\/slots-picker\/cards/
-                ];
-                break;
-              default:
-                console.error('unrecognized bundle for ember-appointment-slots-pickers tree-shaking'); break;//eslint-disable-line
-            }
-            Array.prototype.push.apply(options[clude], patterns);
-          });
+        options.include = options.include || [];
+        Array.prototype.push.apply(options.include, [
+          '**/addon.less'
+        ]);
+
+        options.exclude = options.exclude || [];
+        const bundlesExclude = options.bundles.exclude || [];
+        bundlesExclude.forEach((bundleName) => {
+          let patterns = [];
+          switch(bundleName) {
+            case 'bg':
+              patterns = [
+                /services\/scroll/,
+                /services\/viewport/,
+                /helpers/,
+                '**/global-rules.less',
+                '**/variable.less',
+                /components\/application-pre-loader/,
+                /components\/bg-button/,
+                /components\/scroll-anchor/
+              ];
+              break;
+            case 'mobile':
+              patterns = [
+                /horizontal-list-swiper\/sly/,
+                /components\/date-picker\/mobile/,
+                /components\/date-picker\/mobile\/styles/,
+                /horizontal-list-swiper\/gesture2/,
+                /components\/slots-picker\/mobile/
+              ];
+              break;
+            case 'pickadate':
+              patterns = [
+                /components\/pickadate-input/,
+                /components\/slots-picker\/pickadate/
+              ];
+              break;
+            case 'desktop':
+              patterns = [
+                /horizontal-list-swiper\/gesture/,
+                /components\/slots-picker\/desktop/
+              ];
+              break;
+            case 'cards':
+              patterns = [
+                /components\/slots-picker\/cards/
+              ];
+              break;
+            default:
+              console.error('unrecognized bundle for ember-appointment-slots-pickers tree-shaking'); break;//eslint-disable-line
+          }
+          Array.prototype.push.apply(options.exclude, patterns);
         });
         delete options.bundles;
       }

--- a/index.js
+++ b/index.js
@@ -46,10 +46,6 @@ module.exports = {
     let treeShakingOptions = {};
     if (options) {
       options.include = options.include || [];
-      Array.prototype.push.apply(options.include, [
-        '**/addon.less',
-        '**/mixins.less'
-      ]);
       if (options.bundles) {
 
         options.exclude = options.exclude || [];
@@ -101,8 +97,14 @@ module.exports = {
           Array.prototype.push.apply(options.exclude, patterns);
         });
         delete options.bundles;
+
       }
-      console.log('options.include', options.include);
+      if (options.include.length) {
+        Array.prototype.push.apply(options.include, [
+          '**/addon.less',
+          '**/mixins.less'
+        ]);
+      } //otherwise everything is included by default
       treeShakingOptions = Object.assign({}, {
         enabled: true,
         include: options.include || null,

--- a/index.js
+++ b/index.js
@@ -45,11 +45,12 @@ module.exports = {
     const options = this.app.options[this.name];
     let treeShakingOptions = {};
     if (options) {
+      options.include = options.include || [];
+      Array.prototype.push.apply(options.include, [
+        '**/addon.less',
+        '**/mixins.less'
+      ]);
       if (options.bundles) {
-        options.include = options.include || [];
-        Array.prototype.push.apply(options.include, [
-          '**/addon.less'
-        ]);
 
         options.exclude = options.exclude || [];
         const bundlesExclude = options.bundles.exclude || [];
@@ -101,6 +102,7 @@ module.exports = {
         });
         delete options.bundles;
       }
+      console.log('options.include', options.include);
       treeShakingOptions = Object.assign({}, {
         enabled: true,
         include: options.include || null,

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = {
             /services\/scroll/,
             /services\/viewport/,
             /helpers/,
-            /styles\/global-rules/,
+            /global-rules/,
             /styles\/mixins/,
             /styles\/variables/,
             /components\/application-pre-loader/,

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = {
         options.exclude = options.exclude || [];
         const bundles = options.bundles;
         if (bundles.includes('bg')) {
+          console.log('includes bg');
           options.exclude.push(
             /services\/scroll/,
             /services\/viewport/,
@@ -43,6 +44,8 @@ module.exports = {
             /components\/bg-button/,
             /components\/scroll-anchor/
           )
+        } else {
+          console.log('not includes bg');
         }
         delete options.bundles;
       }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 /* jshint node: true */
 'use strict';
 const MergeTrees = require('broccoli-merge-trees');
-
 const Funnel = require('broccoli-funnel');
 
 module.exports = {
@@ -9,11 +8,16 @@ module.exports = {
   included: function (app) {
     this.app = app;
     this._super.included.apply(this, arguments);
-
-    this.import('node_modules/pickadate/lib/picker.js');
-    this.import('node_modules/pickadate/lib/picker.date.js');
-    this.import('node_modules/pickadate/lib/themes/default.date.css');
-    this.import('node_modules/sly-shim/dist/sly.min.js');
+    const options = app.options[this.name];
+    const exclude = options && options.bundles && options.bundles.exclude || [];
+    if (!exclude.includes('pickadate')) {
+      this.import('node_modules/pickadate/lib/picker.js');
+      this.import('node_modules/pickadate/lib/picker.date.js');
+      this.import('node_modules/pickadate/lib/themes/default.date.css');
+    }
+    if (!exclude.includes('mobile')) {
+      this.import('node_modules/sly-shim/dist/sly.min.js');
+    }
     this.import('node_modules/bootstrap/dist/js/bootstrap.js');
     this.import('node_modules/bootstrap/dist/css/bootstrap.min.css');
   },
@@ -23,30 +27,75 @@ module.exports = {
     }
     return true;
   },
+  _getHostApp: function() {
+    if (!this._findHost) {
+      this._findHost = function findHostShim() {
+        let current = this;
+        let app;
+        do {
+          app = current.app || app;
+        } while (current.parent.parent && (current = current.parent));
+        return app;
+      };
+    }
+
+    return this._findHost();
+  },
   _treeShakingEmber(tree) {
     const options = this.app.options[this.name];
     let treeShakingOptions = {};
-    console.log('options', options, this.app.options, this.name);
     if (options) {
       if (options.bundles) {
-        options.exclude = options.exclude || [];
-        const bundles = options.bundles;
-        if (bundles.includes('bg')) {
-          console.log('includes bg');
-          options.exclude.push(
-            /services\/scroll/,
-            /services\/viewport/,
-            /helpers/,
-            /global-rules/,
-            /styles\/mixins/,
-            /styles\/variables/,
-            /components\/application-pre-loader/,
-            /components\/bg-button/,
-            /components\/scroll-anchor/
-          )
-        } else {
-          console.log('not includes bg');
-        }
+        [/*'include', */'exclude'].forEach((clude) => {
+          options[clude] = options[clude] || [];
+          const bundlesClude = options.bundles[clude];
+          bundlesClude.forEach((bundleName) => {
+            let patterns = [];
+            switch(bundleName) {
+              case 'bg':
+                patterns = [
+                  /services\/scroll/,
+                  /services\/viewport/,
+                  /helpers/,
+                  '**/global-rules.less',
+                  '**/variable.less',
+                  /components\/application-pre-loader/,
+                  /components\/bg-button/,
+                  /components\/scroll-anchor/
+                ];
+                break;
+              case 'mobile':
+                patterns = [
+                  /horizontal-list-swiper\/sly/,
+                  /components\/date-picker\/mobile/,
+                  /components\/date-picker\/mobile\/styles/,
+                  /horizontal-list-swiper\/gesture2/,
+                  /components\/slots-picker\/mobile/
+                ];
+                break;
+              case 'pickadate':
+                patterns = [
+                  /components\/pickadate-input/,
+                  /components\/slots-picker\/pickadate/
+                ];
+                break;
+              case 'desktop':
+                patterns = [
+                  /horizontal-list-swiper\/gesture/,
+                  /components\/slots-picker\/desktop/
+                ];
+                break;
+              case 'cards':
+                patterns = [
+                  /components\/slots-picker\/cards/
+                ];
+                break;
+              default:
+                console.error('unrecognized bundle for ember-appointment-slots-pickers tree-shaking'); break;//eslint-disable-line
+            }
+            Array.prototype.push.apply(options[clude], patterns);
+          });
+        });
         delete options.bundles;
       }
       treeShakingOptions = Object.assign({}, {
@@ -55,11 +104,23 @@ module.exports = {
         exclude: options.exclude || null
       });
     }
-    return new Funnel(tree, treeShakingOptions);
+    const funnel = new Funnel(tree, treeShakingOptions);
+    //console.log('funnel', funnel, funnel.files);
+    return funnel;
   },
   treeForAddon() {
     const tree = this._super.treeForAddon.apply(this, arguments);
     return this._treeShakingEmber(tree);
+  },
+  //https://ember-cli.com/api/files/lib_models_addon.js.html#LINENUM_933
+  ////check https://github.com/ember-engines/ember-engines/blob/master/lib/engine-addon.js
+  ///https://github.com/ember-engines/ember-engines/blob/master/lib/engine-addon.js#L682
+  treeForStyles(tree) {
+    if (!tree) {
+      return tree;
+    }
+    const newTree = this._treeShakingEmber(tree);
+    return this._super.treeForStyles.apply(this, newTree);
   },
 
   treeForApp(appTree) {
@@ -68,4 +129,20 @@ module.exports = {
       overwrite: true
     });
   },
+
+  //this is never run, and I don't know why..
+  /*treeForParentAddonStyles(tree) {
+    return tree;
+  },*/
+
+  _treeFor(name) {
+    const tree = this._super._treeFor.apply(this, arguments);
+    if (name === 'addon-styles') {
+      //treeForParentAddonStyles hook is never run, I don't know why
+      const finalTree = this._treeShakingEmber(tree);
+      return finalTree;
+    }
+    return tree;
+  }
+
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ember-component-css": "github:ConnectedHomes/ember-component-css#experimental"
   },
   "devDependencies": {
+    "broccoli-funnel": "2.0.2",
     "@ember/jquery": "^0.6.1",
     "bootstrap": "3.4.1",
     "broccoli-asset-rev": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,14 @@
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
       "ember": ">=2.18.0 <=3.8.0"
-    }
+    },
+    "after": [
+      "bg-vi",
+      "ember-cli-styles-preprocessor",
+      "ember-cli-less",
+      "ember-cli-sass",
+      "ember-cli-stylus",
+      "ember-cli-postcss"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
       "ember-cli-less",
       "ember-cli-sass",
       "ember-cli-stylus",
-      "ember-cli-postcss"
+      "ember-cli-postcss",
+      "bootstrap"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,15 +63,6 @@
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
       "ember": ">=2.18.0 <=3.8.0"
-    },
-    "after": [
-      "bg-vi",
-      "ember-cli-styles-preprocessor",
-      "ember-cli-less",
-      "ember-cli-sass",
-      "ember-cli-stylus",
-      "ember-cli-postcss",
-      "bootstrap"
-    ]
+    }
   }
 }

--- a/tests/dummy/app/models/appointment-slot.js
+++ b/tests/dummy/app/models/appointment-slot.js
@@ -22,21 +22,17 @@ export default DS.Model.extend({
     }
   }),
 
-  _startMoment: computed('convertToUKTimezone', 'startTime', function () {
+  _startMoment: computed('startTime', function () {
     if (this.get('startTime')) {
-      return this.get('convertToUKTimezone') ?
-        moment(this.get('startTime')).tz('Europe/London') :
-        moment(this.get('startTime'));
+      return moment(this.get('startTime'));
     } else {
       return null;//NB. moment(undefined) or moment(null) returns current/now's date time.
     }
   }),
 
-  _endMoment: computed('convertToUKTimezone', 'endTime', function () {
+  _endMoment: computed('endTime', function () {
     if (this.get('endTime')) {
-      return this.get('convertToUKTimezone') ?
-        moment(this.get('endTime')).tz('Europe/London') :
-        moment(this.get('endTime'));
+      return moment(this.get('endTime'));
     } else {
       return null;//NB. moment(undefined) or moment(null) returns current/now's date time.
     }


### PR DESCRIPTION
Done in this PR:

- [x] allow to tree-shake components
- [x] allow to tree-shake dependencies
- [x] allow to tree-shake CSS

consumed in https://github.com/ConnectedHomes/smart-appointments-engine/pull/446


Status after this PR:

- [x] ~transfer slot-picker components to separate, open-source repo.~ no need with tree-shaking working now, at least for MVP1
- [x] move sly and pickadate bower dependencies out of commons and into npm packages in this repo.
- [x] ~find a solution for `bg-button`, services, helpers and 'scroll-anchor` (should probably not be part of this repo)~ need to be able to tree-shake it out (make a special bg tree-shaking option)
- [x] allow to tree-shake components
- [x] allow to tree-shake dependencies
- [ ] check bootstrap import in index.js and tree-shaking
- [x] create an ember-commons + one app PRs consuming it for backward compatibility
- [ ] make less dependency optional (?)
- [x] reorganize folder structures to have everything under a single namespace instead of flattened components hierarchy
- [x] ~rename the components to `appointment-slots-picker`~
- [x] make sure the latest LTS versions are used in ember-try
- [x] check font-awesome
- [x] github pages
- [ ] check slot-picker/loader image
- [ ] ~refresh and consume https://github.com/britishgas-engineering/ember-window (and add viewport etc.?) ~ no need for MVP1 as tree-shaking 
- [ ] check consuming better bootstrap in commons
- [ ] add appointment-slot-picker in dummy app + tests
- [ ] use https://www.npmjs.com/package/ember-truth-helpers
- [x] ~look at `.tz` references in the dummy app (add to addon? remove altogether from dummy app?)~ separate card on https://github.com/britishgas-engineering/ember-appointment-slots-pickers/issues/13
- [ ] add tree-shaking to readme