### PR TITLE
easy-slot-picker

### DIFF
--- a/addon/components/easy-slot-picker/component.js
+++ b/addon/components/easy-slot-picker/component.js
@@ -1,0 +1,49 @@
+import layout from './template';
+import {getOwner} from '@ember/application';
+import Component from '@ember/component';
+import {inject as service} from '@ember/service';
+import {assert} from '@ember/debug';
+import {computed} from '@ember/object';
+
+export default Component.extend({
+  layout: layout,
+  scroll: service(),
+  viewport: service(),
+  store: service(),
+  // Attributes
+  init() {
+    this._super(...arguments);
+    this.appointmentSlots = this.appointmentSlots || [];
+
+    const owner = getOwner(this);
+    [
+      'slots-picker/loader',
+      'slots-picker/mobile',
+      'slots-picker/desktop'
+    ].forEach((templateName) => {
+      assert(
+        `You now need to add ${templateName} in your tree-shaking to consume easy-slot-picker`,
+        owner.lookup(`component:${templateName}`)
+      );
+    });
+  },
+  selected: null,
+  onSelect: null,
+  noSlotLabel: '',
+  classNames: [
+    'appointment-slot-picker',
+    'text-center'
+  ],
+  classNameBindings: ['isTestEnv'],
+
+  slotPickerComponentName: computed('viewport.isMobile', function () {
+    const showMobile = this.get('viewport.isMobile');
+    return showMobile ? 'slots-picker/mobile' : 'slots-picker/desktop';
+  }),
+  loaderSentence: 'Finding the next available appointments in your area..',
+  actions: {
+    select(appointmentSlot) {
+      return this.get('onSelect') && this.get('onSelect')(appointmentSlot);
+    }
+  }
+});

--- a/addon/components/easy-slot-picker/styles.less
+++ b/addon/components/easy-slot-picker/styles.less
@@ -1,0 +1,242 @@
+& {
+  .asp-container {
+    position: relative;
+  }
+  .asp  {
+    position: relative;
+    z-index: #z.appointment-slot-picker[default];
+  }
+  .asp-overlay {
+    position: absolute;
+    top: 54px;
+    left: 4px;
+    right: 4px;
+    bottom: 4px;
+    border-radius: 8px;
+    background: #fff;
+    z-index: #z.appointment-slot-picker[overlay];
+    display: none;
+    &.active {
+      display: block;
+      //for mobile
+      margin-top: 5px;
+    }
+    @media (max-width: 479px) {
+      top: 85px;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+  }
+  .asp-table {
+    position: relative;
+    border-width: 4px;
+    border-radius: 8px;
+    border-color: #F5F5F5;
+    border-style: solid;
+    overflow: hidden;
+  }
+  .asp-btn {
+    font-size: 16px;
+    display: block;
+    border-radius: 4px;
+    height: 43px;
+    width: 100%;
+    padding: 0px 14px;
+    line-height: 26px;
+    color: @dark-blue;
+    border-color: @dark-blue;
+    font-weight: 600;
+    &:hover {
+      background: @dark-blue;
+      border-color: @dark-blue;
+      color: @white;
+      @media (max-width: 767px) {
+        background: none;
+        color: @dark-blue;;
+      }
+    }
+  }
+  .asp-row-group {
+    border-top: 10px solid rgba(0,0,0,.075);
+  }
+  .asp-row-header {
+    & + .asp-row-group {
+      border-top: none;
+    }
+    .asp-cell {
+      text-transform: capitalize;
+      &.border-right {
+        border-right-width: 4px;
+      }
+    }
+    height: 49px;
+    box-sizing: content-box;
+  }
+  .asp-col {
+    width: 176px;
+    float: left;
+    .asp-row-group:first-child {
+      border: none;
+    }
+    @media (max-width: 479px) {
+      width: 70%;
+    }
+    &.asp-col-header {
+      width: 125px;
+      @media (max-width: 479px) {
+        width: 38.20%;
+      }
+      &.border-right {
+        border-right-width: 4px;
+        border-color: white;
+      }
+    }
+    &:last-child {
+      .asp-row, .asp-cell {
+        border: none;
+      }
+    }
+  }
+  .asp-row {
+    height: 53px;
+    width: 100%;
+    display: table;
+    &.border-right {
+      border-right-width: 4px;
+    }
+  }
+  .asp-cell {
+    padding-left: 15px;
+    padding-right: 15px;
+    width: 100%;
+    height: 100%;
+    display: table-cell;
+    text-align: center;
+    vertical-align: middle;
+    .no-slot-label {
+      font-weight: 500;
+      color: #BBB;
+    }
+    .fa.fa-check {
+      padding-left: 8px;
+      margin-right: -4px;
+      font-size: 18px;
+    }
+  }
+  .asp-scroll {
+    position: absolute;
+    overflow: visible;
+    top: 0;
+    left: 125px;
+    right: 0;
+    bottom: 0;
+    @media (max-width: 479px) {
+      left: 100px;
+    }
+  }
+  .asp-scroll-area-wrapper {
+    height: 100%;
+    width: 100%;
+    z-index: #z.appointment-slot-picker[default];
+    overflow:hidden;
+  }
+  .asp-scroll-area {
+    transition: all .8s ease-in-out;
+  }
+  .asp-fade-left {
+    .horizontal-gradient(rgba(255,255,255,1), rgba(255,255,255,0));
+    top: 53px;
+    bottom: 0;
+    width: 40px;
+    position: absolute;
+    left: 0;
+  }
+  .asp-fade-right {
+    .horizontal-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+    top: 53px;
+    bottom: 0;
+    width: 40px;
+    position: absolute;
+    right: 0;
+  }
+  .asp-scroll-btn {
+    position: absolute;
+    background: none;
+    border: none;
+    padding: 0;
+    height: 49px;
+    min-width: 36px;
+    outline: none;
+    z-index: #z.appointment-slot-picker[overlay];
+    background: @dark-blue;;
+    & .fa {
+      font-size: 24px;
+    }
+    & span:not(.fa) {
+      font-size: 24px;
+      vertical-align: text-bottom;
+    }
+    &:before {
+      content: '';
+      position: absolute;
+      width: 20px;
+      height: 100%;
+      top: 0;
+      pointer-events: none;
+    }
+    &.asp-scroll-btn-prev {
+      left: 0;
+      padding: 0 8px;
+      margin-left: -50px;
+      &:before {
+        right: -20px;
+      }
+    }
+    &.asp-scroll-btn-next {
+      right: 0;
+      padding: 0 8px;
+      &:before {
+        .horizontal-gradient(rgba(0,94,184,0), rgba(0,94,184,1));
+        left: -20px;
+      }
+    }
+  }
+  .asp-appointment-slot-selected {
+    font-size: 16px;
+    display: block;
+    border-radius: 4px;
+    height: 43px;
+    line-height: 43px;
+    width: 100%;
+  }
+  .animated {
+    .horizontal-swipe-view-list {
+      transition: .4s all;
+    }
+  }
+  .slots-are-loading {
+    background-image: url(/content/dam/british-gas/beta/svg/dot-loader-dark-blue.svg);
+    background-repeat: no-repeat;
+    background-position: 50% 60%;
+  }
+  .application-pre-loader {
+    margin-bottom: 150px;
+    margin-top: 30px;
+    .crop {
+      //remove the bottom, "loading.." part of the image
+      //https://stackoverflow.com/a/493329/4325661
+      width: 100px;
+      height: 80px;
+      overflow: hidden;
+      position: absolute;
+      left: 0;
+      right: 0;
+      margin: auto;
+      display: block;
+      img.pre-loader {
+        margin-bottom: -50px;
+      }
+    }
+  }
+}

--- a/addon/components/easy-slot-picker/template.hbs
+++ b/addon/components/easy-slot-picker/template.hbs
@@ -1,0 +1,18 @@
+{{#slots-picker
+  appointmentSlots=appointmentSlots
+  selected=selected
+  noSlotLabel=noSlotLabel
+  select=(action 'select')
+  as |baseProps onSelectSlot onDeselectSlot|
+}}
+  {{#if baseProps.slotsAreLoading}}
+    {{slots-picker/loader title=loaderSentence}}
+  {{else}}
+    {{component slotPickerComponentName
+      baseProps=baseProps
+      onSelectSlot=onSelectSlot
+      onDeselectSlot=onDeselectSlot
+    }}
+    {{slots-picker/selection-single baseProps=baseProps}}
+  {{/if}}
+{{/slots-picker}}

--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -4,6 +4,7 @@
 @import (optional) "node_modules/bg-vi/src/styles/custom-bg/variables.less";
 @import (optional) "node_modules/bg-vi/src/styles/brands/sainsburys/variables.less";
 @import (optional) "node_modules/bg-vi/src/styles/brands/britishgas/variables.less";
+@import (optional) "node_modules/ember-commons/styles/z-indexes.less";
 
 @import "./mixins.less";
 @import (optional) "./global-rules.less"; //non "bg" bundles only
@@ -26,3 +27,4 @@
 @import (optional) "./components/slots-picker/selection-multi/styles.less";
 @import (optional) "./components/slots-picker/mobile/styles.less";
 @import (optional) "./components/slots-picker/styles.less";
+@import (optional) "./components/easy-slot-picker/styles.less";

--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -2,9 +2,10 @@
 @import (optional) "./variables.less";
 //"bg" bundles only
 @import (optional) "node_modules/bg-vi/src/styles/custom-bg/variables.less";
+@import (optional) "node_modules/bg-vi/src/styles/bgcss/bgcss-variables.less";
 @import (optional) "node_modules/bg-vi/src/styles/brands/sainsburys/variables.less";
 @import (optional) "node_modules/bg-vi/src/styles/brands/britishgas/variables.less";
-@import (optional) "node_modules/ember-commons/styles/z-indexes.less";
+@import (optional) "node_modules/ember-commons/addon/styles/z-indexes.less";
 
 @import "./mixins.less";
 @import (optional) "./global-rules.less"; //non "bg" bundles only

--- a/addon/styles/global-rules.less
+++ b/addon/styles/global-rules.less
@@ -1,3 +1,13 @@
+#z() {
+  .appointment-slot-picker(){
+    default: 1;
+    overlay: 2;
+  }
+  .mobile-date-picker(){
+    default: 10;
+  }
+}
+
 .ember-appointment-slots-pickers {
   li {
     list-style: none;

--- a/app/components/easy-slot-picker/component.js
+++ b/app/components/easy-slot-picker/component.js
@@ -1,0 +1,1 @@
+export {default} from 'ember-appointment-slots-pickers/components/easy-slot-picker/component';

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
     return this._findHost();
   },
   _debug() {
-    //console.log(...arguments);
+    console.log(...arguments);
   },
   _treeShakingEmber(tree) {
     const options = this.app.options[this.name];
@@ -136,11 +136,10 @@ module.exports = {
       treeShakingOptions = Object.assign({}, {
         enabled: true,
         include: options.include || null,
-        exclude: /*options.exclude ||*/ null
+        exclude: options.exclude || null
       });
     }
     const funnel = new Funnel(tree, treeShakingOptions);
-    //console.log('funnel', funnel, funnel.files);
     return funnel;
   },
   treeForAddon() {

--- a/index.js
+++ b/index.js
@@ -47,57 +47,78 @@ module.exports = {
     if (options) {
       options.include = options.include || [];
       if (options.bundles) {
-
-        options.exclude = options.exclude || [];
-        const bundlesExclude = options.bundles.exclude || [];
-        bundlesExclude.forEach((bundleName) => {
-          let patterns = [];
-          switch(bundleName) {
-            case 'bg':
-              patterns = [
-                /services\/scroll/,
-                /services\/viewport/,
-                /helpers/,
-                '**/global-rules.less',
-                '**/variable.less',
-                /components\/application-pre-loader/,
-                /components\/bg-button/,
-                /components\/scroll-anchor/
-              ];
-              break;
-            case 'mobile':
-              patterns = [
-                /horizontal-list-swiper\/sly/,
-                /components\/date-picker\/mobile/,
-                /components\/date-picker\/mobile\/styles/,
-                /horizontal-list-swiper\/gesture2/,
-                /components\/slots-picker\/mobile/
-              ];
-              break;
-            case 'pickadate':
-              patterns = [
-                /components\/pickadate-input/,
-                /components\/slots-picker\/pickadate/
-              ];
-              break;
-            case 'desktop':
-              patterns = [
-                /horizontal-list-swiper\/gesture/,
-                /components\/slots-picker\/desktop/
-              ];
-              break;
-            case 'cards':
-              patterns = [
-                /components\/slots-picker\/cards/
-              ];
-              break;
-            default:
-              console.error('unrecognized bundle for ember-appointment-slots-pickers tree-shaking'); break;//eslint-disable-line
+        ['exclude', 'include'].forEach((includeOrExclude) => {
+          options[includeOrExclude] = options[includeOrExclude] || [];
+          let bundles = options.bundles[includeOrExclude] || [];
+          if (bundles.includes('easy')) {
+            bundles = bundles.filter((elt) => elt !== 'easy');
+            bundles.push('desktop', 'mobile');
+            options[includeOrExclude].push(/components\/easy-slot-picker/);
           }
-          Array.prototype.push.apply(options.exclude, patterns);
-        });
+          bundles.forEach((bundleName) => {
+            let patterns = [];
+            switch(bundleName) {
+              case 'bg':
+                patterns = [
+                  /services\/scroll/,
+                  /services\/viewport/,
+                  /helpers/,
+                  '**/global-rules.less',
+                  '**/variable.less',
+                  /components\/application-pre-loader/,
+                  /components\/bg-button/,
+                  /components\/scroll-anchor/
+                ];
+                break;
+              case 'mobile':
+                patterns = [
+                  /horizontal-list-swiper\/sly/,
+                  /components\/date-picker\/mobile/,
+                  /components\/date-picker\/mobile\/styles/,
+                  /horizontal-list-swiper\/gesture2/,
+                  /components\/slots-picker\/mobile/
+                ];
+                break;
+              case 'pickadate':
+                patterns = [
+                  /components\/pickadate-input/,
+                  /components\/slots-picker\/pickadate/
+                ];
+                break;
+              case 'desktop':
+                patterns = [
+                  /horizontal-list-swiper\/gesture/,
+                  /components\/slots-picker\/desktop/
+                ];
+                break;
+              case 'cards':
+                patterns = [
+                  /components\/slots-picker\/cards/
+                ];
+                break;
+              default:
+                console.error('unrecognized bundle for ember-appointment-slots-pickers tree-shaking'); break;//eslint-disable-line
+            }
+            Array.prototype.push.apply(options[includeOrExclude], patterns);
+          });
+        })
+        if (options.bundles.include.length) { //files needed for any calendar
+          Array.prototype.push.apply(options.include, [
+            /components\/slots-picker\/base/,
+            /components\/slots-picker\/button/,
+            /components\/slots-picker\/loader/,
+            /components\/slots-picker\/selection-multi/,
+            /components\/slots-picker\/selection-single/,
+            /components\/horizontal-list-swiper\/no-delay-on-transitions-in-test/,
+            /slots-picker\/component/,
+            /slots-picker\/styles/,
+            /slots-picker\/template/,
+            /components\/bg-button/,
+            /services/,
+            /helpers/
+          ]);
+        }
         delete options.bundles;
-
       }
       if (options.include.length) {
         Array.prototype.push.apply(options.include, [

--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ module.exports = {
             /components\/bg-button/,
             /services/,
             /helpers/,
-            '**/styles.less',
             '**/ember-appointment-slots-pickers.css'
           ]);
         }

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
     return this._findHost();
   },
   _debug() {
-    console.log(...arguments);
+    //console.log(...arguments);
   },
   _treeShakingEmber(tree) {
     const options = this.app.options[this.name];

--- a/index.js
+++ b/index.js
@@ -41,17 +41,40 @@ module.exports = {
 
     return this._findHost();
   },
+  _debug() {
+    //console.log(...arguments);
+  },
   _treeShakingEmber(tree) {
     const options = this.app.options[this.name];
     let treeShakingOptions = {};
     if (options) {
       options.include = options.include || [];
       if (options.bundles) {
+
+        if (options.bundles.include && options.bundles.include.length) { //files needed for any calendar
+          Array.prototype.push.apply(options.include, [
+            /components\/slots-picker\/base/,
+            /components\/slots-picker\/button/,
+            /components\/slots-picker\/loader/,
+            /components\/slots-picker\/selection-multi/,
+            /components\/slots-picker\/selection-single/,
+            /components\/horizontal-list-swiper\/no-delay-on-transitions-in-test/,
+            /slots-picker\/component/,
+            /slots-picker\/styles/,
+            /slots-picker\/template/,
+            /components\/bg-button/,
+            /services/,
+            /helpers/,
+            '**/styles.less',
+            '**/ember-appointment-slots-pickers.css'
+          ]);
+        }
+
         ['exclude', 'include'].forEach((includeOrExclude) => {
           options[includeOrExclude] = options[includeOrExclude] || [];
           let bundles = options.bundles[includeOrExclude] || [];
           if (bundles.includes('easy')) {
-            bundles = bundles.filter((elt) => elt !== 'easy');
+            //bundles = bundles.filter((elt) => elt !== 'easy');
             bundles.push('desktop', 'mobile');
             options[includeOrExclude].push(/components\/easy-slot-picker/);
           }
@@ -64,7 +87,7 @@ module.exports = {
                   /services\/viewport/,
                   /helpers/,
                   '**/global-rules.less',
-                  '**/variable.less',
+                  '**/variables.less',
                   /components\/application-pre-loader/,
                   /components\/bg-button/,
                   /components\/scroll-anchor/
@@ -97,27 +120,11 @@ module.exports = {
                 ];
                 break;
               default:
-                console.error('unrecognized bundle for ember-appointment-slots-pickers tree-shaking'); break;//eslint-disable-line
+                console.error('unrecognized bundle for ember-appointment-slots-pickers tree-shaking: ', bundleName); break;//eslint-disable-line
             }
             Array.prototype.push.apply(options[includeOrExclude], patterns);
           });
         })
-        if (options.bundles.include.length) { //files needed for any calendar
-          Array.prototype.push.apply(options.include, [
-            /components\/slots-picker\/base/,
-            /components\/slots-picker\/button/,
-            /components\/slots-picker\/loader/,
-            /components\/slots-picker\/selection-multi/,
-            /components\/slots-picker\/selection-single/,
-            /components\/horizontal-list-swiper\/no-delay-on-transitions-in-test/,
-            /slots-picker\/component/,
-            /slots-picker\/styles/,
-            /slots-picker\/template/,
-            /components\/bg-button/,
-            /services/,
-            /helpers/
-          ]);
-        }
         delete options.bundles;
       }
       if (options.include.length) {
@@ -126,10 +133,11 @@ module.exports = {
           '**/mixins.less'
         ]);
       } //otherwise everything is included by default
+      this._debug('ember-appointment-slots-pickers treeShaking debug:', options);
       treeShakingOptions = Object.assign({}, {
         enabled: true,
         include: options.include || null,
-        exclude: options.exclude || null
+        exclude: /*options.exclude ||*/ null
       });
     }
     const funnel = new Funnel(tree, treeShakingOptions);

--- a/tests/dummy/app/demo/slots-pickers/easy-slot-picker/template.hbs
+++ b/tests/dummy/app/demo/slots-pickers/easy-slot-picker/template.hbs
@@ -1,0 +1,28 @@
+<div class="container-fluid">
+
+  <h1>easy-slot-picker</h1>
+  <h2> Very simple to implement, with default functionalities: </h2>
+  <h2>desktop + mobile hybrid, single selection, default loader</h2>
+  <h2>Not customizable nor composable.</h2>
+
+  <h3>Default</h3>
+    <hr>
+  <div class="mb8">
+    {{easy-slot-picker
+      appointmentSlots=model.showableSlots
+      selected=model.selected
+      onSelect=(action (mut model.selected))
+    }}
+  </div>
+
+  <h3>Loading state ({{delay}} ms, change with queryParam ?delay=10000)</h3>
+  <hr>
+  <div class="mb8">
+    {{easy-slot-picker
+      appointmentSlots=model.asyncSlots
+      selected=model.selected
+      onSelect=(action (mut model.selected))
+    }}
+  </div>
+  <hr>
+</div>

--- a/tests/dummy/app/demo/slots-pickers/template.hbs
+++ b/tests/dummy/app/demo/slots-pickers/template.hbs
@@ -1,5 +1,6 @@
 <h1>slots pickers</h1>
 
+{{link-to "easy" "demo.slots-pickers.easy-slot-picker" class="m3 btn btn-primary"}}
 {{#each slotPickerNames as |slotPickerName|}}
   {{link-to slotPickerName "demo.slots-pickers.slot-picker-name" slotPickerName class="m3 btn btn-primary" }}
 {{/each}}

--- a/tests/dummy/app/index/template.hbs
+++ b/tests/dummy/app/index/template.hbs
@@ -1,6 +1,7 @@
 <div class="container mt10 ember-appointment-slots-pickers">
   <h1 id="title">Ember appointment slots pickers</h1>
   <ul>
+    <li>{{#link-to "demo.slots-pickers.easy-slot-picker"}}easy-slot-picker{{/link-to}}</li>
     <li>{{#link-to "demo.horizontal-list-swipers"}}horizontal-list swipers{{/link-to}}</li>
     <li>{{#link-to "demo.date-pickers"}}date pickers{{/link-to}}</li>
     <li>{{#link-to "demo.slots-pickers"}}slots pickers{{/link-to}}</li>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('demo', function () {
     this.route('slots-filter');
     this.route('slots-pickers', function () {
+      this.route('easy-slot-picker');
       this.route('slot-picker-name', {path: '/:slot-picker-name'});//eslint-disable-line
     });
     this.route('clock-reloader');

--- a/tests/integration/easy-slot-picker/component-test.js
+++ b/tests/integration/easy-slot-picker/component-test.js
@@ -1,0 +1,84 @@
+import {module, test} from 'qunit';
+import {setupRenderingTest} from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { generateAppointmentSlots } from 'ember-appointment-slots-pickers/test-support/helpers/generate-appointment-slots';
+import Ember from 'ember';
+
+import {render, settled, findAll} from '@ember/test-helpers';
+
+const emberAssertCp = Ember.assert; // eslint-disable-line
+
+module('Integration | Component | easy-slot-picker', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    //silence Ember.assert for other components presence, check didInsertElement hook of the component
+    Ember.assert = () => {}; // eslint-disable-line
+  });
+
+  hooks.afterEach(function () {
+    Ember.assert = emberAssertCp; // eslint-disable-line
+  });
+
+  test('should bind appointment slots to component and not scroll', async function (assert) {
+    assert.expect(6);
+    // Generate no appointments first to simulate loading
+    generateAppointmentSlots.call(this, {
+      numberOfAppointments: 0
+    });
+
+    // Test component is not there now to prove it will be added later
+    //assert.equal(this.$('.appointment-slot-picker').length === 1, false, 'has not yet rendered');
+
+    // Render the component //NB. set width to replicate small desktop screens scroll bug #2342
+    await render(hbs`
+      <div>
+        {{easy-slot-picker appointmentSlots=generatedAppointmentSlots}}
+      </div>
+    `);
+
+    // Test the component is there but with no appointments
+    assert.equal(findAll('.appointment-slot-picker').length === 1, true, 'should render component');
+    assert.equal(findAll('.asp-btn').length > 0, false, 'has no available appointments');
+
+    return settled().then(() => {
+      //Generate appointments after the component has rendered
+      generateAppointmentSlots.call(this, {
+        numberOfAppointments: 50
+      });
+
+      // Test that there are now appointments
+      assert.equal(findAll('.asp-btn').length > 0, true, 'has some available appointments loaded afterwards');
+
+      // Test fixed bug where was scrolling past first appointments for small desktop screens #2342
+      assert.equal(findAll('.asp-scroll-btn-prev').length > 0, false, 'does not have previous button as shows the first appointments');
+
+      // test for brand (cyan0 0class has been added for background-color, for britishgas
+      assert.equal(findAll('.asp-row.asp-row-header.background-dark-blue').length > 0, true, 'default Brand background color has been applied');
+      assert.equal(
+        findAll('.asp-cell button').length,
+        this.get('availableAppointmentSlots.length'),
+        'has as many buttons as there are available slots');
+    });
+  });
+
+  test('should show mobile calendar if slotPickerComponentName is slots-picker/mobile', async function (assert) {
+    this.set('slotPickerComponentName', 'slots-picker/mobile');
+    generateAppointmentSlots.call(this, {
+      numberOfAppointments: 10
+    });
+    await render(hbs`
+      <div style="width:460px">
+        {{easy-slot-picker
+          slotPickerComponentName=slotPickerComponentName
+          appointmentSlots=generatedAppointmentSlots
+        }}
+      </div>
+    `);
+    assert.equal(
+      findAll('.date-picker-mobile').length,
+      1,
+      'mobile calendar version has rendered as isLimitedAvailability is true and showSmartCalendar is false.'
+    );
+  });
+});

--- a/tests/unit/easy-slot-picker/component-test.js
+++ b/tests/unit/easy-slot-picker/component-test.js
@@ -1,0 +1,40 @@
+import {module} from 'qunit';
+import {test} from 'qunit'; import {setupTest} from 'ember-qunit';
+import Ember from 'ember';
+
+const emberAssertCp = Ember.assert; //eslint-disable-line
+
+module('Unit | Component | easy-slot-picker', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    //silence assert for other components presence, check didInsertElement hook of the component
+    Ember.assert = () => {}; //eslint-disable-line
+  });
+
+  hooks.afterEach(function () {
+    Ember.assert = emberAssertCp; //eslint-disable-line
+  });
+
+  test('slotPickerComponentName responsiveBreak', function (assert) {
+    const component = this.owner.factoryFor('component:easy-slot-picker').create({
+      viewport: {
+        isMobile: false
+      }
+    });
+
+    assert.equal(
+      component.get('slotPickerComponentName'),
+      'slots-picker/desktop',
+      'slots-picker-/esktop returned for large viewports'
+    );
+
+    component.set('viewport.isMobile', true);
+
+    assert.equal(
+      component.get('slotPickerComponentName'),
+      'slots-picker/mobile',
+      'slots-picker/mobile returned for small viewports'
+    );
+  });
+});


### PR DESCRIPTION
Done in this PR:

- [x] add `appointment-slot-picker`  (renamed as `easy-slot-picker`) for those who want it

consumed in https://github.com/ConnectedHomes/ember-on-demand/pull/894

and also
https://github.com/ConnectedHomes/ember-commons/pull/4952
https://github.com/ConnectedHomes/new-home/pull/741
https://github.com/ConnectedHomes/smart-appointments-engine/pull/446


Status after this PR:

- [ ] add wiki for easy-slot-picker
- [ ] add wiki for tree-shaking
- [x] ~transfer slot-picker components to separate, open-source repo.~ no need with tree-shaking working now, at least for MVP1
- [x] move sly and pickadate bower dependencies out of commons and into npm packages in this repo.
- [x] ~find a solution for `bg-button`, services, helpers and 'scroll-anchor` (should probably not be part of this repo)~ need to be able to tree-shake it out (make a special bg tree-shaking option)
- [x] allow to tree-shake components
- [x] allow to tree-shake dependencies
- [ ] check bootstrap import in index.js and tree-shaking
- [x] create an ember-commons + one app PRs consuming it for backward compatibility
- [ ] make less dependency optional (?)
- [x] reorganize folder structures to have everything under a single namespace instead of flattened components hierarchy
- [x] ~rename the components to `appointment-slots-picker`~
- [x] make sure the latest LTS versions are used in ember-try
- [x] check font-awesome
- [x] github pages
- [ ] check slot-picker/loader image
- [ ] check default loader assertions, including use of `Ember` in tests
- [ ] ~refresh and consume https://github.com/britishgas-engineering/ember-window (and add viewport etc.?)~ no need for MVP1 as tree-shaking 
- [ ] check consuming better bootstrap in commons
- [x] add appointment-slot-picker in dummy app + tests
- [ ] use https://www.npmjs.com/package/ember-truth-helpers
- [x] ~look at `.tz` references in the dummy app (add to addon? remove altogether from dummy app?)~ separate card on https://github.com/britishgas-engineering/ember-appointment-slots-pickers/issues/13

breaking changes: 
*`slotPickerXX` properties
* easy-slot-picker camelized props
* tree-shaking
* appointment-slot-picker => easy-slot-picker