### PR TITLE
changed ul>li to div to avoid ndsn styles impacting

### DIFF
--- a/addon/components/horizontal-list-swiper/sly/styles.less
+++ b/addon/components/horizontal-list-swiper/sly/styles.less
@@ -11,7 +11,7 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    & > li {
+    & > .scroll-header-sly-item {
       float: left;
       margin: 0;
       padding: 0;

--- a/addon/components/horizontal-list-swiper/sly/template.hbs
+++ b/addon/components/horizontal-list-swiper/sly/template.hbs
@@ -1,9 +1,9 @@
 <div class="scroll-header-sly-frame">
-  <ul class="scroll-header-sly-slidee">
+  <div role="list" class="scroll-header-sly-slidee">
     {{#each itemsUpdate as |item itemIndex|}}
-      <li class="scroll-header-sly-item">
+      <div role="listitem" class="scroll-header-sly-item">
         {{yield item itemIndex}}
-      </li>
+      </div>
     {{/each}}
-  </ul>
+  </div>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-appointment-slots-pickers",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-appointment-slots-pickers",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Appointment slot pickers component suite written in Ember.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
`easy-slot-picker` does not render properly in mobile due to CSS override by Nucleus styles.

Nucleus ndsn styles are impacting the `<ul class="scroll-header-sly-slidee">` and `<li class="scroll-header-sly-item">`. Not all the days are displayed due to this problem.