### PR TITLE
Remove the classification column completely from the calendar BTM 860

### DIFF
--- a/addon/components/slots-picker/desktop-no-category-column/component.js
+++ b/addon/components/slots-picker/desktop-no-category-column/component.js
@@ -1,0 +1,8 @@
+import layout from './template';
+import { computed } from '@ember/object';
+import slotPickerBase from 'ember-appointment-slots-pickers/components/slots-picker/desktop/component';
+
+export default slotPickerBase.extend({
+  layout
+
+});

--- a/addon/components/slots-picker/desktop-no-category-column/component.js
+++ b/addon/components/slots-picker/desktop-no-category-column/component.js
@@ -1,8 +1,6 @@
 import layout from './template';
-import { computed } from '@ember/object';
 import slotPickerBase from 'ember-appointment-slots-pickers/components/slots-picker/desktop/component';
 
 export default slotPickerBase.extend({
   layout
-
 });

--- a/addon/components/slots-picker/desktop-no-category-column/styles.less
+++ b/addon/components/slots-picker/desktop-no-category-column/styles.less
@@ -1,0 +1,40 @@
+& {
+  .asp-table {
+    .asp-col.asp-col-header {
+      width: 70px;
+      @media (max-width: 479px) {
+        width: 38.20%;
+      }
+      
+      &.border-right {
+        border-right-width: 4px;
+        border-color: white;
+      }
+    }
+    .ember-appointment-slots-pickers:first-child{
+      position:inherit;
+      left:0;
+      .asp-scroll-btn-prev{
+        left:50px;
+      }
+      .asp-scroll-btn-next{
+        width:38px;
+        span:first-child{
+          display:none;
+        }   
+      }
+    }
+    .asp-row.asp-row-header {
+      .asp-cell {
+        padding: 0px;
+        height: 43px;
+        text-transform: capitalize;
+        &.border-right {
+          border-right-width: 4px;
+        }
+      }
+      height: 49px;
+      box-sizing: content-box;
+    }
+  }
+}

--- a/addon/components/slots-picker/desktop-no-category-column/template.hbs
+++ b/addon/components/slots-picker/desktop-no-category-column/template.hbs
@@ -1,0 +1,44 @@
+{{#if slotsAreLoading}}
+  {{slots-picker/loader}}
+{{else}}
+  <div class="asp-desktop">
+    <div class="asp-table">
+
+
+      {{#horizontal-list-swiper/gesture index=selectedDayIndex items=cellsPerCol as |item|}}
+
+        <div class="asp-col font-size-8">
+
+          <div class="asp-row asp-row-header background-dark-blue white">
+            <div class="asp-cell border-right border-white">
+              {{item.col.dayLabel}}
+            </div>
+          </div>
+
+          {{#each item.cellsForCol as |cell index|}}
+            <div class="asp-row border-right border-light-grey {{if (has-a-delimiter rows index) 'delimiter'}}">
+              <div class="asp-cell">
+                {{#if cell}}
+                  {{slots-picker/button
+                    appointmentSlot=cell
+                    multiSelected=multiSelected
+                    canSelectMultipleSlots=canSelectMultipleSlots
+                    select=(action onSelectSlot)
+                    deselect=(optional-action onDeselectSlot)
+                  }}
+                {{else}}
+                  <div class="no-slot-label">
+                    {{if noSlotLabel noSlotLabel 'Fully booked'}}
+                  </div>
+                {{/if}}
+              </div>
+            </div>
+
+          {{/each}}
+
+        </div>
+
+      {{/horizontal-list-swiper/gesture}}
+    </div>
+  </div>
+{{/if}}

--- a/addon/components/slots-picker/desktop-no-category-column/template.hbs
+++ b/addon/components/slots-picker/desktop-no-category-column/template.hbs
@@ -8,7 +8,6 @@
       {{#horizontal-list-swiper/gesture index=selectedDayIndex items=cellsPerCol as |item|}}
 
         <div class="asp-col font-size-8">
-
           <div class="asp-row asp-row-header background-dark-blue white">
             <div class="asp-cell border-right border-white">
               {{item.col.dayLabel}}
@@ -16,7 +15,7 @@
           </div>
 
           {{#each item.cellsForCol as |cell index|}}
-            <div class="asp-row border-right border-light-grey {{if (has-a-delimiter rows index) 'delimiter'}}">
+            <div class="asp-row border-right border-light-grey }}">
               <div class="asp-cell">
                 {{#if cell}}
                   {{slots-picker/button

--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -23,6 +23,7 @@
 @import (optional) "./components/slots-picker/cards/styles.less";
 @import (optional) "./components/slots-picker/day-card/styles.less";
 @import (optional) "./components/slots-picker/desktop/styles.less";
+@import (optional) "./components/slots-picker/desktop-no-category-column/styles.less";
 @import (optional) "./components/slots-picker/loader/styles.less";
 @import (optional) "./components/slots-picker/mobile/styles.less";
 @import (optional) "./components/slots-picker/pickadate/styles.less";

--- a/app/components/slots-picker/desktop-no-category-column/component.js
+++ b/app/components/slots-picker/desktop-no-category-column/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-appointment-slots-pickers/components/slots-picker/desktop-no-category-column/component';

--- a/tests/dummy/app/demo/slots-pickers/controller.js
+++ b/tests/dummy/app/demo/slots-pickers/controller.js
@@ -7,6 +7,7 @@ export default Controller.extend({
     this._super(...arguments);
     this.slotPickerNames = this.slotPickerNames || [
       'desktop',
+      'desktop-no-category-column',
       'mobile',
       'cards',
       'pickadate'

--- a/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
+++ b/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
@@ -1,26 +1,105 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import {
+  module} from 'qunit'; import {setupRenderingTest
+} from 'ember-qunit';
+import { test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { generateAppointmentSlots } from 'ember-appointment-slots-pickers/test-support/helpers/generate-appointment-slots';
+import { run } from '@ember/runloop';
+import { render, settled, findAll } from '@ember/test-helpers';
 
-module('Integration | Component | slots-picker/desktop-no-category-column', function(hooks) {
+module('Integration | Component | slots-picker/desktop-no-category-column', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  hooks.beforeEach(function () {
+    this.actions = {};
+    this.send = (actionName, ...args) => this.actions[actionName].apply(this, args);
+  });
 
-    await render(hbs`{{slots-picker/desktop-no-category-column}}`);
+  test('with slots available, no slot selected', async function (assert) {
 
-    assert.equal(this.element.textContent.trim(), '');
+    generateAppointmentSlots.call(this, {
+      numberOfAppointments: 50
+    });
+    this.set('testSelect', () => {});
 
-    // Template block usage:
     await render(hbs`
-      {{#slots-picker/desktop-no-category-column}}
-        template block text
-      {{/slots-picker/desktop-no-category-column}}
+      <div>
+        {{#slots-picker
+          appointmentSlots=generatedAppointmentSlots
+          select=(action testSelect)
+          as |baseProps onSelectSlot|
+        }}
+          {{slots-picker/desktop-no-category-column
+            baseProps=baseProps
+            onSelectSlot=onSelectSlot
+          }}
+        {{/slots-picker}}
+      </div>
     `);
+   
+    assert.equal(findAll('.asp-btn').length > 0, true, 'has some available appointments loaded afterwards');
+    debugger;
+    assert.equal(findAll('.asp-col-header').length > 0, false, 'should not have category column');
+    assert.equal(findAll('.asp-scroll-btn-prev').length > 0, false, 'does not have previous button as shows the first appointments');
+    assert.equal(
+      findAll('.asp-col-header .asp-row.delimiter').length,
+      0,
+      'has no delimiter in the header column'
+    );
+    debugger;
+    assert.equal(
+      this.$('.asp-scroll .asp-col:eq(0) .asp-row.delimiter').length,
+      0,
+      'has no delimiter in the first non-header column'
+    );
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.equal(findAll('.asp-row.asp-row-header.background-dark-blue').length > 0, true, 'default Brand background color has been applied');
+    assert.equal(
+      findAll('.asp-cell button').length,
+      this.get('availableAppointmentSlots.length'),
+      'has as many buttons as there are available slots');
+  });
+
+  test('with slots available, last slot selected', async function (assert) {
+
+    generateAppointmentSlots.call(this, {
+      numberOfAppointments: 50
+    });
+    this.actions.testSelect = () => {};
+    const generatedAppointmentSlots = this.get('generatedAppointmentSlots');
+    const selectedSlot = generatedAppointmentSlots[generatedAppointmentSlots.length - 1];
+    let availableAppointmentSlots;
+    run(() => {
+      selectedSlot.set('available', false);
+      availableAppointmentSlots = generatedAppointmentSlots.filterBy('available', true);
+    });
+    this.set('selected', selectedSlot);
+    await render(hbs`
+      <div>
+        {{#slots-picker
+          appointmentSlots=generatedAppointmentSlots
+          select=(action 'testSelect')
+          selected=selected
+          as |baseProps onSelectSlot|
+        }}
+          {{slots-picker/desktop-no-category-column
+            baseProps=baseProps
+            onSelectSlot=onSelectSlot
+          }}
+        {{/slots-picker}}
+      </div>
+    `);
+    return settled().then(() => {
+
+      assert.equal(findAll('.asp-btn').length > 0, true, 'has some available appointments loaded afterwards');
+      assert.equal(findAll('.asp-scroll-btn-prev').length > 0, true, 'has previous button');
+      assert.equal(findAll('.asp-scroll-btn-next').length > 0, false, 'does not have next button as shows the last appointments');
+
+      assert.equal(findAll('.asp-row.asp-row-header.background-dark-blue').length > 0, true, 'default Brand background color has been applied');
+      assert.equal(
+        findAll('.asp-cell button').length,
+        availableAppointmentSlots.get('length'),
+        'has as many buttons as there are available slots');
+    });
   });
 });

--- a/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
+++ b/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
@@ -38,7 +38,6 @@ module('Integration | Component | slots-picker/desktop-no-category-column', func
     `);
    
     assert.equal(findAll('.asp-btn').length > 0, true, 'has some available appointments loaded afterwards');
-    debugger;
     assert.equal(findAll('.asp-col-header').length > 0, false, 'should not have category column');
     assert.equal(findAll('.asp-scroll-btn-prev').length > 0, false, 'does not have previous button as shows the first appointments');
     assert.equal(
@@ -46,7 +45,6 @@ module('Integration | Component | slots-picker/desktop-no-category-column', func
       0,
       'has no delimiter in the header column'
     );
-    debugger;
     assert.equal(
       this.$('.asp-scroll .asp-col:eq(0) .asp-row.delimiter').length,
       0,

--- a/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
+++ b/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | slots-picker/desktop-no-category-column', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{slots-picker/desktop-no-category-column}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#slots-picker/desktop-no-category-column}}
+        template block text
+      {{/slots-picker/desktop-no-category-column}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
**Remove the classification column completely from the calendar**

_ This classification column doesn’t add any value to the slots and it is logical to remove them as there is already work in progress to redesign the calendar_

JIRA:https://centrica.atlassian.net/browse/BTM-860 


- [x] Created a new component desktop-no-category-column 

- [x] fix test cases