### PR TITLE
Remove the classification column completely from the calendar

### DIFF
--- a/addon/components/slots-picker/desktop-no-category-column/component.js
+++ b/addon/components/slots-picker/desktop-no-category-column/component.js
@@ -1,0 +1,8 @@
+import layout from './template';
+import { computed } from '@ember/object';
+import slotPickerBase from 'ember-appointment-slots-pickers/components/slots-picker/desktop/component';
+
+export default slotPickerBase.extend({
+  layout
+
+});

--- a/addon/components/slots-picker/desktop-no-category-column/component.js
+++ b/addon/components/slots-picker/desktop-no-category-column/component.js
@@ -1,8 +1,6 @@
 import layout from './template';
-import { computed } from '@ember/object';
 import slotPickerBase from 'ember-appointment-slots-pickers/components/slots-picker/desktop/component';
 
 export default slotPickerBase.extend({
   layout
-
 });

--- a/addon/components/slots-picker/desktop-no-category-column/styles.less
+++ b/addon/components/slots-picker/desktop-no-category-column/styles.less
@@ -16,6 +16,7 @@
       left:0;
       .asp-scroll-btn-prev{
         left:51px;
+        
       }
       .asp-scroll-btn-prev:before{
         background:linear-gradient(to left, rgba(0, 94, 184, 0), #005eb8);

--- a/addon/components/slots-picker/desktop-no-category-column/styles.less
+++ b/addon/components/slots-picker/desktop-no-category-column/styles.less
@@ -15,7 +15,7 @@
       position:inherit;
       left:0;
       .asp-scroll-btn-prev{
-        left:47px;
+        left:51px;
       }
       .asp-scroll-btn-prev:before{
         background:linear-gradient(to left, rgba(0, 94, 184, 0), #005eb8);

--- a/addon/components/slots-picker/desktop-no-category-column/styles.less
+++ b/addon/components/slots-picker/desktop-no-category-column/styles.less
@@ -16,7 +16,6 @@
       left:0;
       .asp-scroll-btn-prev{
         left:50px;
-
       }
       .asp-scroll-btn-prev:before{
         background:linear-gradient(to left, rgba(0, 94, 184, 0), #005eb8);

--- a/addon/components/slots-picker/desktop-no-category-column/styles.less
+++ b/addon/components/slots-picker/desktop-no-category-column/styles.less
@@ -1,0 +1,40 @@
+& {
+  .asp-table {
+    .asp-col.asp-col-header {
+      width: 70px;
+      @media (max-width: 479px) {
+        width: 38.20%;
+      }
+      
+      &.border-right {
+        border-right-width: 4px;
+        border-color: white;
+      }
+    }
+    .ember-appointment-slots-pickers:first-child{
+      position:inherit;
+      left:0;
+      .asp-scroll-btn-prev{
+        left:50px;
+      }
+      .asp-scroll-btn-next{
+        width:38px;
+        span:first-child{
+          display:none;
+        }   
+      }
+    }
+    .asp-row.asp-row-header {
+      .asp-cell {
+        padding: 0px;
+        height: 43px;
+        text-transform: capitalize;
+        &.border-right {
+          border-right-width: 4px;
+        }
+      }
+      height: 49px;
+      box-sizing: content-box;
+    }
+  }
+}

--- a/addon/components/slots-picker/desktop-no-category-column/styles.less
+++ b/addon/components/slots-picker/desktop-no-category-column/styles.less
@@ -15,7 +15,10 @@
       position:inherit;
       left:0;
       .asp-scroll-btn-prev{
-        left:50px;
+        left:47px;
+      }
+      .asp-scroll-btn-prev:before{
+        background:linear-gradient(to left, rgba(0, 94, 184, 0), #005eb8);
       }
       .asp-scroll-btn-next{
         width:38px;

--- a/addon/components/slots-picker/desktop-no-category-column/styles.less
+++ b/addon/components/slots-picker/desktop-no-category-column/styles.less
@@ -15,8 +15,8 @@
       position:inherit;
       left:0;
       .asp-scroll-btn-prev{
-        left:51px;
-        
+        left:50px;
+
       }
       .asp-scroll-btn-prev:before{
         background:linear-gradient(to left, rgba(0, 94, 184, 0), #005eb8);

--- a/addon/components/slots-picker/desktop-no-category-column/template.hbs
+++ b/addon/components/slots-picker/desktop-no-category-column/template.hbs
@@ -1,0 +1,44 @@
+{{#if slotsAreLoading}}
+  {{slots-picker/loader}}
+{{else}}
+  <div class="asp-desktop">
+    <div class="asp-table">
+
+
+      {{#horizontal-list-swiper/gesture index=selectedDayIndex items=cellsPerCol as |item|}}
+
+        <div class="asp-col font-size-8">
+
+          <div class="asp-row asp-row-header background-dark-blue white">
+            <div class="asp-cell border-right border-white">
+              {{item.col.dayLabel}}
+            </div>
+          </div>
+
+          {{#each item.cellsForCol as |cell index|}}
+            <div class="asp-row border-right border-light-grey {{if (has-a-delimiter rows index) 'delimiter'}}">
+              <div class="asp-cell">
+                {{#if cell}}
+                  {{slots-picker/button
+                    appointmentSlot=cell
+                    multiSelected=multiSelected
+                    canSelectMultipleSlots=canSelectMultipleSlots
+                    select=(action onSelectSlot)
+                    deselect=(optional-action onDeselectSlot)
+                  }}
+                {{else}}
+                  <div class="no-slot-label">
+                    {{if noSlotLabel noSlotLabel 'Fully booked'}}
+                  </div>
+                {{/if}}
+              </div>
+            </div>
+
+          {{/each}}
+
+        </div>
+
+      {{/horizontal-list-swiper/gesture}}
+    </div>
+  </div>
+{{/if}}

--- a/addon/components/slots-picker/desktop-no-category-column/template.hbs
+++ b/addon/components/slots-picker/desktop-no-category-column/template.hbs
@@ -8,7 +8,6 @@
       {{#horizontal-list-swiper/gesture index=selectedDayIndex items=cellsPerCol as |item|}}
 
         <div class="asp-col font-size-8">
-
           <div class="asp-row asp-row-header background-dark-blue white">
             <div class="asp-cell border-right border-white">
               {{item.col.dayLabel}}
@@ -16,7 +15,7 @@
           </div>
 
           {{#each item.cellsForCol as |cell index|}}
-            <div class="asp-row border-right border-light-grey {{if (has-a-delimiter rows index) 'delimiter'}}">
+            <div class="asp-row border-right border-light-grey }}">
               <div class="asp-cell">
                 {{#if cell}}
                   {{slots-picker/button

--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -23,6 +23,7 @@
 @import (optional) "./components/slots-picker/cards/styles.less";
 @import (optional) "./components/slots-picker/day-card/styles.less";
 @import (optional) "./components/slots-picker/desktop/styles.less";
+@import (optional) "./components/slots-picker/desktop-no-category-column/styles.less";
 @import (optional) "./components/slots-picker/loader/styles.less";
 @import (optional) "./components/slots-picker/mobile/styles.less";
 @import (optional) "./components/slots-picker/pickadate/styles.less";

--- a/app/components/slots-picker/desktop-no-category-column/component.js
+++ b/app/components/slots-picker/desktop-no-category-column/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-appointment-slots-pickers/components/slots-picker/desktop-no-category-column/component';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-appointment-slots-pickers",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5661,6 +5661,42 @@
         "moment-timezone": "^0.5.13"
       },
       "dependencies": {
+        "amd-name-resolver": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.1"
+          }
+        },
+        "babel-plugin-debug-macros": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
+          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+          "dev": true,
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "broccoli-babel-transpiler": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
+          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "dev": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "broccoli-funnel": "^2.0.1",
+            "broccoli-merge-trees": "^2.0.0",
+            "broccoli-persistent-filter": "^1.4.3",
+            "clone": "^2.0.0",
+            "hash-for-dep": "^1.2.3",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^4.8.2",
+            "workerpool": "^2.3.0"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
@@ -5771,6 +5807,39 @@
             "ms": "^2.1.1"
           }
         },
+        "ember-get-config": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.4.tgz",
+          "integrity": "sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=",
+          "dev": true,
+          "requires": {
+            "broccoli-file-creator": "^1.1.1",
+            "ember-cli-babel": "^6.3.0"
+          },
+          "dependencies": {
+            "ember-cli-babel": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+              "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+              "dev": true,
+              "requires": {
+                "amd-name-resolver": "1.2.0",
+                "babel-plugin-debug-macros": "^0.2.0-beta.6",
+                "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-preset-env": "^1.7.0",
+                "broccoli-babel-transpiler": "^6.5.0",
+                "broccoli-debug": "^0.6.4",
+                "broccoli-funnel": "^2.0.0",
+                "broccoli-source": "^1.1.0",
+                "clone": "^2.0.0",
+                "ember-cli-version-checker": "^2.1.2",
+                "semver": "^5.5.0"
+              }
+            }
+          }
+        },
         "fs-extra": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
@@ -5794,6 +5863,15 @@
             "heimdalljs-logger": "^0.1.7",
             "rimraf": "^2.4.3",
             "symlink-or-copy": "^1.0.0"
+          }
+        },
+        "workerpool": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
+          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1"
           }
         }
       }
@@ -6855,137 +6933,6 @@
             "hash-for-dep": "^1.2.3",
             "json-stable-stringify": "^1.0.0",
             "strip-bom": "^3.0.0"
-          }
-        },
-        "merge-trees": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
-          "requires": {
-            "can-symlink": "^1.0.0",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1"
-          }
-        }
-      }
-    },
-    "ember-get-config": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-0.2.4.tgz",
-      "integrity": "sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=",
-      "dev": true,
-      "requires": {
-        "broccoli-file-creator": "^1.1.1",
-        "ember-cli-babel": "^6.3.0"
-      },
-      "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
-          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
-          "requires": {
-            "babel-core": "^6.26.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.0.0",
-            "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^4.8.2",
-            "workerpool": "^2.3.0"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "merge-trees": "^1.0.1"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
           }
         },
         "merge-trees": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-appointment-slots-pickers",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Appointment slot pickers component suite written in Ember.",
   "keywords": [
     "ember-addon"

--- a/tests/dummy/app/demo/slots-pickers/controller.js
+++ b/tests/dummy/app/demo/slots-pickers/controller.js
@@ -7,6 +7,7 @@ export default Controller.extend({
     this._super(...arguments);
     this.slotPickerNames = this.slotPickerNames || [
       'desktop',
+      'desktop-no-category-column',
       'mobile',
       'cards',
       'pickadate'

--- a/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
+++ b/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
@@ -1,26 +1,105 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import {
+  module} from 'qunit'; import {setupRenderingTest
+} from 'ember-qunit';
+import { test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { generateAppointmentSlots } from 'ember-appointment-slots-pickers/test-support/helpers/generate-appointment-slots';
+import { run } from '@ember/runloop';
+import { render, settled, findAll } from '@ember/test-helpers';
 
-module('Integration | Component | slots-picker/desktop-no-category-column', function(hooks) {
+module('Integration | Component | slots-picker/desktop-no-category-column', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  hooks.beforeEach(function () {
+    this.actions = {};
+    this.send = (actionName, ...args) => this.actions[actionName].apply(this, args);
+  });
 
-    await render(hbs`{{slots-picker/desktop-no-category-column}}`);
+  test('with slots available, no slot selected', async function (assert) {
 
-    assert.equal(this.element.textContent.trim(), '');
+    generateAppointmentSlots.call(this, {
+      numberOfAppointments: 50
+    });
+    this.set('testSelect', () => {});
 
-    // Template block usage:
     await render(hbs`
-      {{#slots-picker/desktop-no-category-column}}
-        template block text
-      {{/slots-picker/desktop-no-category-column}}
+      <div>
+        {{#slots-picker
+          appointmentSlots=generatedAppointmentSlots
+          select=(action testSelect)
+          as |baseProps onSelectSlot|
+        }}
+          {{slots-picker/desktop-no-category-column
+            baseProps=baseProps
+            onSelectSlot=onSelectSlot
+          }}
+        {{/slots-picker}}
+      </div>
     `);
+   
+    assert.equal(findAll('.asp-btn').length > 0, true, 'has some available appointments loaded afterwards');
+    debugger;
+    assert.equal(findAll('.asp-col-header').length > 0, false, 'should not have category column');
+    assert.equal(findAll('.asp-scroll-btn-prev').length > 0, false, 'does not have previous button as shows the first appointments');
+    assert.equal(
+      findAll('.asp-col-header .asp-row.delimiter').length,
+      0,
+      'has no delimiter in the header column'
+    );
+    debugger;
+    assert.equal(
+      this.$('.asp-scroll .asp-col:eq(0) .asp-row.delimiter').length,
+      0,
+      'has no delimiter in the first non-header column'
+    );
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.equal(findAll('.asp-row.asp-row-header.background-dark-blue').length > 0, true, 'default Brand background color has been applied');
+    assert.equal(
+      findAll('.asp-cell button').length,
+      this.get('availableAppointmentSlots.length'),
+      'has as many buttons as there are available slots');
+  });
+
+  test('with slots available, last slot selected', async function (assert) {
+
+    generateAppointmentSlots.call(this, {
+      numberOfAppointments: 50
+    });
+    this.actions.testSelect = () => {};
+    const generatedAppointmentSlots = this.get('generatedAppointmentSlots');
+    const selectedSlot = generatedAppointmentSlots[generatedAppointmentSlots.length - 1];
+    let availableAppointmentSlots;
+    run(() => {
+      selectedSlot.set('available', false);
+      availableAppointmentSlots = generatedAppointmentSlots.filterBy('available', true);
+    });
+    this.set('selected', selectedSlot);
+    await render(hbs`
+      <div>
+        {{#slots-picker
+          appointmentSlots=generatedAppointmentSlots
+          select=(action 'testSelect')
+          selected=selected
+          as |baseProps onSelectSlot|
+        }}
+          {{slots-picker/desktop-no-category-column
+            baseProps=baseProps
+            onSelectSlot=onSelectSlot
+          }}
+        {{/slots-picker}}
+      </div>
+    `);
+    return settled().then(() => {
+
+      assert.equal(findAll('.asp-btn').length > 0, true, 'has some available appointments loaded afterwards');
+      assert.equal(findAll('.asp-scroll-btn-prev').length > 0, true, 'has previous button');
+      assert.equal(findAll('.asp-scroll-btn-next').length > 0, false, 'does not have next button as shows the last appointments');
+
+      assert.equal(findAll('.asp-row.asp-row-header.background-dark-blue').length > 0, true, 'default Brand background color has been applied');
+      assert.equal(
+        findAll('.asp-cell button').length,
+        availableAppointmentSlots.get('length'),
+        'has as many buttons as there are available slots');
+    });
   });
 });

--- a/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
+++ b/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
@@ -38,7 +38,6 @@ module('Integration | Component | slots-picker/desktop-no-category-column', func
     `);
    
     assert.equal(findAll('.asp-btn').length > 0, true, 'has some available appointments loaded afterwards');
-    debugger;
     assert.equal(findAll('.asp-col-header').length > 0, false, 'should not have category column');
     assert.equal(findAll('.asp-scroll-btn-prev').length > 0, false, 'does not have previous button as shows the first appointments');
     assert.equal(
@@ -46,7 +45,6 @@ module('Integration | Component | slots-picker/desktop-no-category-column', func
       0,
       'has no delimiter in the header column'
     );
-    debugger;
     assert.equal(
       this.$('.asp-scroll .asp-col:eq(0) .asp-row.delimiter').length,
       0,

--- a/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
+++ b/tests/integration/components/slots-picker/desktop-no-category-column/component-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | slots-picker/desktop-no-category-column', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{slots-picker/desktop-no-category-column}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#slots-picker/desktop-no-category-column}}
+        template block text
+      {{/slots-picker/desktop-no-category-column}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
**Remove the classification column completely from the calendar**

_ This classification column doesn’t add any value to the slots and it is logical to remove them as there is already work in progress to redesign the calendar_

JIRA:https://centrica.atlassian.net/browse/BTM-860 


- [x] Created a new component desktop-no-category-column 

- [x] fix test cases