### PR TITLE
Epic/pickadate temporary fix hi tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "10"
+  - "14"
 
 sudo: false
 

--- a/addon/components/pickadate-input/component.js
+++ b/addon/components/pickadate-input/component.js
@@ -58,8 +58,10 @@ export default Component.extend({
 
   onPickerFocus: function () {
     // alert('focus');
-    this.$('.picker__holder').blur();
-    return false;
+    if (this.$('.picker__holder')) {
+      this.$('.picker__holder').blur();
+      return false;
+    }
   },
 
   /**

--- a/addon/components/pickadate-input/component.js
+++ b/addon/components/pickadate-input/component.js
@@ -58,7 +58,7 @@ export default Component.extend({
 
   onPickerFocus: function () {
     // alert('focus');
-    if (this.$('.picker__holder')) {
+    if (document.querySelector('.picker__holder')) {
       this.$('.picker__holder').blur();
       return false;
     }

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "deploy": "ember build --environment production && ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\" && git push origin gh-pages:gh-pages"
   },
   "dependencies": {
-    "ember-cli-babel": "7.7.3",
+    "ember-cli-babel": "^7.24.0",
     "ember-cli-htmlbars": "3.0.1",
     "ember-cli-htmlbars-inline-precompile": "2.1.0",
-    "pickadate": "3.6.4",
-    "sly-shim": "1.6.1",
     "ember-cli-less": "2.0.1",
     "ember-component-css": "github:ConnectedHomes/ember-component-css#experimental",
-    "ember-truth-helpers": "2.1.0"
+    "ember-truth-helpers": "2.1.0",
+    "pickadate": "3.6.4",
+    "sly-shim": "1.6.1"
   },
   "devDependencies": {
     "broccoli-funnel": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-appointment-slots-pickers",
-  "version": "0.2.7",
+  "version": "2.0.0",
   "description": "Appointment slot pickers component suite written in Ember.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-appointment-slots-pickers",
-  "version": "1.0.0",
+  "version": "0.2.7",
   "description": "Appointment slot pickers component suite written in Ember.",
   "keywords": [
     "ember-addon"

--- a/tests/unit/pickadate-input/component-test.js
+++ b/tests/unit/pickadate-input/component-test.js
@@ -1,0 +1,29 @@
+import { module } from 'qunit';
+import {
+  test} from 'qunit'; import {setupTest
+} from 'ember-qunit';
+
+module('Unit | Component | slots-picker/pickadate input', function (hooks) {
+  setupTest(hooks);
+
+  test('on blur method calls', function (assert) {
+    const blurSpy = sinon.spy();
+    const stub = sinon.stub(document, 'querySelector').returns(false);
+    const component = this.owner.factoryFor('component:pickadate-input').create({
+      $: sinon.stub().returns({blur: blurSpy}),
+    });
+    component.onPickerFocus();
+    assert.ok(blurSpy.notCalled, 'not called the blur spy');
+    stub.restore();
+  });
+  test('on blur method calls true', function (assert) {
+    const blurSpy = sinon.spy();
+    const stub = sinon.stub(document, 'querySelector').returns(true);
+    const component = this.owner.factoryFor('component:pickadate-input').create({
+      $: sinon.stub().returns({blur: blurSpy}),
+    });
+    component.onPickerFocus();
+    assert.ok(blurSpy.called, 'called the blur spy');
+    stub.restore();
+  });
+});


### PR DESCRIPTION
This is a temporary fix to make acceptance tests pass in home-insurance app pass after ember upgrade 3.24.0.

There is an issue in production where the pickadate component scrolls when date is clicked. Prod incident will be raised to get it fixed properly.